### PR TITLE
Feat: 장바구니 , 결제 , 주문내역 및 주문/배송 상태 기능 구현

### DIFF
--- a/src/main/java/com/example/web_spring/Cart/Cart.java
+++ b/src/main/java/com/example/web_spring/Cart/Cart.java
@@ -4,9 +4,11 @@ import com.example.web_spring.Member.Member;
 import com.example.web_spring.Product.Product;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class Cart {
 
     @Id
@@ -23,5 +25,20 @@ public class Cart {
 
     private int quantity;
     private int price;
+
+    public Cart(Member member, Product product, int quantity, int price) {
+        this.member = member;
+        this.product = product;
+        this.quantity = quantity;
+        this.price = price;
+    }
+
+    public void addQuantity() {
+        this.quantity++;
+    }
+
+    public void removeQuantity() {
+        if (this.quantity > 1) this.quantity--;
+    }
 
 }

--- a/src/main/java/com/example/web_spring/Cart/CartController.java
+++ b/src/main/java/com/example/web_spring/Cart/CartController.java
@@ -17,6 +17,10 @@ public class CartController {
     @GetMapping("/cart")
     public String cartPage(Model model, Principal principal) {
 
+        if (principal != null) {
+            model.addAttribute("userName", principal.getName());
+        }
+
         var items = cartService.getCartItems(principal.getName());
 
         model.addAttribute("cartItems", items);

--- a/src/main/java/com/example/web_spring/Cart/CartController.java
+++ b/src/main/java/com/example/web_spring/Cart/CartController.java
@@ -1,0 +1,55 @@
+package com.example.web_spring.Cart;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+
+@Controller
+@RequiredArgsConstructor
+public class CartController {
+
+    private final CartService cartService;
+
+    /** 장바구니 조회 */
+    @GetMapping("/cart")
+    public String cartPage(Model model, Principal principal) {
+
+        var items = cartService.getCartItems(principal.getName());
+
+        model.addAttribute("cartItems", items);
+        model.addAttribute("totalPrice", cartService.getTotalPrice(items));
+
+        return "cart/cart";
+    }
+
+    /** 장바구니 추가 */
+    @PostMapping("/cart/add/{productId}")
+    public String add(@PathVariable Long productId, Principal principal) {
+        cartService.addToCart(productId, principal.getName());
+        return "redirect:/cart";
+    }
+
+    /** 수량 증가 */
+    @PostMapping("/cart/plus/{productId}")
+    public String plus(@PathVariable Long productId, Principal principal) {
+        cartService.increaseQuantity(productId, principal.getName());
+        return "redirect:/cart";
+    }
+
+    /** 수량 감소 */
+    @PostMapping("/cart/minus/{productId}")
+    public String minus(@PathVariable Long productId, Principal principal) {
+        cartService.decreaseQuantity(productId, principal.getName());
+        return "redirect:/cart";
+    }
+
+    /** 삭제 */
+    @PostMapping("/cart/delete/{productId}")
+    public String delete(@PathVariable Long productId, Principal principal) {
+        cartService.deleteItem(productId, principal.getName());
+        return "redirect:/cart";
+    }
+}

--- a/src/main/java/com/example/web_spring/Cart/CartRepository.java
+++ b/src/main/java/com/example/web_spring/Cart/CartRepository.java
@@ -1,7 +1,17 @@
 package com.example.web_spring.Cart;
 
+import com.example.web_spring.Member.Member;
+import com.example.web_spring.Product.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
+    List<Cart> findByMember(Member member);
+
+    Optional<Cart> findByMemberAndProduct(Member member, Product product);
+
+    void deleteByMemberAndProduct(Member member, Product product);
 }

--- a/src/main/java/com/example/web_spring/Cart/CartService.java
+++ b/src/main/java/com/example/web_spring/Cart/CartService.java
@@ -1,0 +1,93 @@
+package com.example.web_spring.Cart;
+
+import com.example.web_spring.Member.Member;
+import com.example.web_spring.Member.MemberRepository;
+import com.example.web_spring.Product.Product;
+import com.example.web_spring.Product.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CartService {
+
+    private final CartRepository cartRepository;
+    private final MemberRepository memberRepository;
+    private final ProductRepository productRepository;
+
+    /** 장바구니 조회 */
+    public List<Cart> getCartItems(String username) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+        return cartRepository.findByMember(member);
+    }
+
+    /** 총 금액 */
+    public int getTotalPrice(List<Cart> cartList) {
+        return cartList.stream()
+                .mapToInt(c -> c.getPrice() * c.getQuantity())
+                .sum();
+    }
+
+    /** 장바구니 추가 */
+    @Transactional
+    public void addToCart(Long productId, String username) {
+
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("상품이 존재하지 않습니다."));
+
+        cartRepository.findByMemberAndProduct(member, product)
+                .ifPresentOrElse(
+                        Cart::addQuantity,
+                        () -> cartRepository.save(new Cart(member, product, 1, product.getPrice()))
+                );
+    }
+
+    /** 수량 증가 */
+    @Transactional
+    public void increaseQuantity(Long productId, String username) {
+
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("상품이 존재하지 않습니다."));
+
+        Cart cart = cartRepository.findByMemberAndProduct(member, product)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니에 해당 상품이 없습니다."));
+
+        cart.addQuantity();
+    }
+
+    /** 수량 감소 */
+    @Transactional
+    public void decreaseQuantity(Long productId, String username) {
+
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("상품이 존재하지 않습니다."));
+
+        Cart cart = cartRepository.findByMemberAndProduct(member, product)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니에 해당 상품이 없습니다."));
+
+        cart.removeQuantity();
+    }
+
+    /** 삭제 */
+    @Transactional
+    public void deleteItem(Long productId, String username) {
+
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("상품이 존재하지 않습니다."));
+
+        cartRepository.deleteByMemberAndProduct(member, product);
+    }
+}

--- a/src/main/java/com/example/web_spring/Cart/CartService.java
+++ b/src/main/java/com/example/web_spring/Cart/CartService.java
@@ -106,4 +106,14 @@ public class CartService {
                 .mapToInt(Cart::getQuantity)
                 .sum();
     }
+    @Transactional
+    public void clearCart(String username) {
+
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+        List<Cart> cartItems = cartRepository.findByMember(member);
+
+        cartRepository.deleteAll(cartItems);
+    }
 }

--- a/src/main/java/com/example/web_spring/Cart/CartService.java
+++ b/src/main/java/com/example/web_spring/Cart/CartService.java
@@ -90,4 +90,20 @@ public class CartService {
 
         cartRepository.deleteByMemberAndProduct(member, product);
     }
+
+    /** 총 금액(username 기반) */
+    public int getTotalPrice(String username) {
+        List<Cart> cartList = getCartItems(username);
+        return cartList.stream()
+                .mapToInt(c -> c.getPrice() * c.getQuantity())
+                .sum();
+    }
+
+    /** 총 수량(username 기반) */
+    public int getTotalQuantity(String username) {
+        List<Cart> cartList = getCartItems(username);
+        return cartList.stream()
+                .mapToInt(Cart::getQuantity)
+                .sum();
+    }
 }

--- a/src/main/java/com/example/web_spring/Delivery/Delivery.java
+++ b/src/main/java/com/example/web_spring/Delivery/Delivery.java
@@ -27,6 +27,9 @@ public class Delivery {
     public void setOrder(Order order) {
         this.order = order;
     }
+    public void setState(DeliveryState state) {
+        this.state = state;
+    }
 
     public static Delivery create(Order order, String address) {
         Delivery delivery = new Delivery();

--- a/src/main/java/com/example/web_spring/Delivery/Delivery.java
+++ b/src/main/java/com/example/web_spring/Delivery/Delivery.java
@@ -3,9 +3,11 @@ package com.example.web_spring.Delivery;
 import com.example.web_spring.Order.Order;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class Delivery {
 
     @Id
@@ -33,6 +35,14 @@ public class Delivery {
         delivery.trackingNo = "준비중";
         delivery.state = DeliveryState.READY;
         return delivery;
+    }
+
+    /** 비즈니스 생성자 */
+    public Delivery(Order order, String trackingNo, String address, DeliveryState state) {
+        this.order = order;
+        this.trackingNo = trackingNo;
+        this.address = address;
+        this.state = state;
     }
 }
 

--- a/src/main/java/com/example/web_spring/Delivery/Delivery.java
+++ b/src/main/java/com/example/web_spring/Delivery/Delivery.java
@@ -21,5 +21,18 @@ public class Delivery {
 
     @Enumerated(EnumType.STRING)
     private DeliveryState state;
+
+    public void setOrder(Order order) {
+        this.order = order;
+    }
+
+    public static Delivery create(Order order, String address) {
+        Delivery delivery = new Delivery();
+        delivery.order = order;
+        delivery.address = address;
+        delivery.trackingNo = "준비중";
+        delivery.state = DeliveryState.READY;
+        return delivery;
+    }
 }
 

--- a/src/main/java/com/example/web_spring/Delivery/DeliveryState.java
+++ b/src/main/java/com/example/web_spring/Delivery/DeliveryState.java
@@ -1,9 +1,21 @@
 package com.example.web_spring.Delivery;
 
-// 배송 상태 Enum
-enum DeliveryState {
-    PENDING, // 배송 대기
-    PREPARING, // 상품준비
-    SHIPPING, // 배송증
-    COMPLETED // 배송완료
+import lombok.Getter;
+
+@Getter
+public enum DeliveryState {
+
+    READY("배송준비중", "secondary"),
+    SHIPPING("배송중", "info"),
+    DELIVERED("배송완료", "success"),
+    RETURN_REQUESTED("반품요청", "warning"),
+    RETURNED("반품완료", "dark");
+
+    private final String korean;
+    private final String badgeClass;
+
+    DeliveryState(String korean, String badgeClass) {
+        this.korean = korean;
+        this.badgeClass = badgeClass;
+    }
 }

--- a/src/main/java/com/example/web_spring/Delivery/DeliveryState.java
+++ b/src/main/java/com/example/web_spring/Delivery/DeliveryState.java
@@ -9,7 +9,7 @@ public enum DeliveryState {
     SHIPPING("배송중", "info"),
     DELIVERED("배송완료", "success"),
     RETURN_REQUESTED("반품요청", "warning"),
-    RETURNED("반품완료", "dark");
+    RETURNED("반품완료", "primary");
 
     private final String korean;
     private final String badgeClass;

--- a/src/main/java/com/example/web_spring/Order/Order.java
+++ b/src/main/java/com/example/web_spring/Order/Order.java
@@ -1,28 +1,53 @@
 package com.example.web_spring.Order;
-
 import com.example.web_spring.Member.Member;
+import com.example.web_spring.OrderItem.OrderItem;
+import com.example.web_spring.Payment.PaymentMethod;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
-@Table(name = "orders") // SQL 예약어 'Order' 충돌 방지
+@Table(name = "orders")
 @Getter
+@NoArgsConstructor
 public class Order {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id; // PK
+    private Long id;
 
+    // 주문자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
+    // 총 금액
     private int totalPrice;
+
+    // 주문 날짜
     private LocalDateTime orderDate;
 
+    // 주문 상태 (결제대기, 결제완료, 배송중 등)
     @Enumerated(EnumType.STRING)
     private OrderStatus status;
+
+    // 배송 정보
+    private String receiver;
+    private String phoneNumber;
+    private String address;
+
+    // 결제 수단
+    @Enumerated(EnumType.STRING)
+    private PaymentMethod paymentMethod;
+
+    // 주문 상품 목록
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
+    private List<OrderItem> orderItems = new ArrayList<>();
+
 
     @PrePersist
     public void prePersist() {
@@ -31,6 +56,27 @@ public class Order {
             this.status = OrderStatus.PAYMENT_PENDING;
         }
     }
-}
 
-// 주문 상태 Enum
+
+    //== 생성 메서드 ==//
+    public static Order create(Member member,
+                               TemporaryOrder temp,
+                               int totalPrice,
+                               PaymentMethod method) {
+
+        Order order = new Order();
+        order.member = member;
+        order.receiver = temp.getReceiver();
+        order.phoneNumber = temp.getPhoneNumber();
+        order.address = temp.getAddress();
+        order.totalPrice = totalPrice;
+        order.paymentMethod = method;
+        order.status = OrderStatus.PAYMENT_COMPLETED; // 결제시 주문 완료
+        return order;
+    }
+
+    public void addOrderItem(OrderItem item) {
+        this.orderItems.add(item);
+        item.setOrder(this);
+    }
+}

--- a/src/main/java/com/example/web_spring/Order/Order.java
+++ b/src/main/java/com/example/web_spring/Order/Order.java
@@ -59,6 +59,23 @@ public class Order {
             this.status = OrderStatus.PAYMENT_PENDING;
         }
     }
+    public Order(Member member,
+                 String receiver,
+                 String phoneNumber,
+                 String address,
+                 int totalPrice,
+                 PaymentMethod paymentMethod,
+                 OrderStatus status) {
+
+        this.member = member;
+        this.receiver = receiver;
+        this.phoneNumber = phoneNumber;
+        this.address = address;
+        this.totalPrice = totalPrice;
+        this.paymentMethod = paymentMethod;
+        this.status = status;
+        this.orderDate = LocalDateTime.now();
+    }
 
 
     //== 생성 메서드 ==//

--- a/src/main/java/com/example/web_spring/Order/Order.java
+++ b/src/main/java/com/example/web_spring/Order/Order.java
@@ -1,4 +1,5 @@
 package com.example.web_spring.Order;
+import com.example.web_spring.Delivery.Delivery;
 import com.example.web_spring.Member.Member;
 import com.example.web_spring.OrderItem.OrderItem;
 import com.example.web_spring.Payment.PaymentMethod;
@@ -48,6 +49,8 @@ public class Order {
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private List<OrderItem> orderItems = new ArrayList<>();
 
+    @OneToOne(mappedBy = "order", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private Delivery delivery;
 
     @PrePersist
     public void prePersist() {
@@ -78,5 +81,13 @@ public class Order {
     public void addOrderItem(OrderItem item) {
         this.orderItems.add(item);
         item.setOrder(this);
+    }
+
+    protected void setStatus(OrderStatus status) {
+        this.status = status;
+    }
+
+    public void setDelivery(Delivery delivery) {
+        this.delivery = delivery;
     }
 }

--- a/src/main/java/com/example/web_spring/Order/OrderController.java
+++ b/src/main/java/com/example/web_spring/Order/OrderController.java
@@ -70,4 +70,16 @@ public class OrderController {
 
         return "redirect:/mypage/orders";
     }
+
+    @PostMapping("/order/refund/{id}")
+    public String refundOrder(
+            @PathVariable Long id,
+            Principal principal) {
+
+        String username = principal.getName();
+        orderService.refundOrder(id, username);
+
+        return "redirect:/mypage/orders";
+    }
+
 }

--- a/src/main/java/com/example/web_spring/Order/OrderController.java
+++ b/src/main/java/com/example/web_spring/Order/OrderController.java
@@ -5,9 +5,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
 import java.security.Principal;
+import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
@@ -35,5 +37,37 @@ public class OrderController {
         orderService.saveTemporaryOrder(form, username);
 
         return "redirect:/payment";
+    }
+
+    @GetMapping("/order/complete/{id}")
+    public String orderComplete(@PathVariable Long id, Model model, Principal principal) {
+
+        Order order = orderService.findOrderById(id);
+
+        model.addAttribute("order", order);
+        model.addAttribute("userName", principal.getName());
+
+        return "order/order_complete";
+    }
+
+    @GetMapping("/mypage/orders")
+    public String myOrders(Model model, Principal principal) {
+
+        String username = principal.getName();
+
+        List<Order> orders = orderService.findOrdersByUsername(username);
+
+        model.addAttribute("orders", orders);
+        model.addAttribute("userName", username);
+
+        return "mypage/order_list";
+    }
+
+    @PostMapping("/order/cancel/{id}")
+    public String cancelOrder(@PathVariable Long id, Principal principal) {
+
+        orderService.cancelOrder(id, principal.getName());
+
+        return "redirect:/mypage/orders";
     }
 }

--- a/src/main/java/com/example/web_spring/Order/OrderController.java
+++ b/src/main/java/com/example/web_spring/Order/OrderController.java
@@ -1,0 +1,39 @@
+package com.example.web_spring.Order;
+
+import com.example.web_spring.Cart.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import java.security.Principal;
+
+@Controller
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final CartService cartService;
+    private final OrderService orderService;
+
+    @GetMapping("/order")
+    public String orderForm(Model model, Principal principal) {
+
+        String username = principal.getName();
+
+        model.addAttribute("orderTotal", cartService.getTotalPrice(username));
+        model.addAttribute("orderCount", cartService.getTotalQuantity(username));
+
+        return "order/order_form";
+    }
+
+    @PostMapping("/order")
+    public String submitOrder(OrderFormDto form, Principal principal) {
+
+        String username = principal.getName();
+
+        orderService.saveTemporaryOrder(form, username);
+
+        return "redirect:/payment";
+    }
+}

--- a/src/main/java/com/example/web_spring/Order/OrderFormDto.java
+++ b/src/main/java/com/example/web_spring/Order/OrderFormDto.java
@@ -1,0 +1,11 @@
+package com.example.web_spring.Order;
+
+import lombok.Data;
+
+@Data
+public class OrderFormDto {
+
+    private String receiver;
+    private String phoneNumber;
+    private String address;
+}

--- a/src/main/java/com/example/web_spring/Order/OrderRepository.java
+++ b/src/main/java/com/example/web_spring/Order/OrderRepository.java
@@ -1,6 +1,10 @@
 package com.example.web_spring.Order;
 
+import com.example.web_spring.Member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface OrderRepository extends JpaRepository<Order, Long> {
+    List<Order> findByMemberOrderByIdDesc(Member member);
 }

--- a/src/main/java/com/example/web_spring/Order/OrderService.java
+++ b/src/main/java/com/example/web_spring/Order/OrderService.java
@@ -3,6 +3,7 @@ package com.example.web_spring.Order;
 import com.example.web_spring.Cart.Cart;
 import com.example.web_spring.Cart.CartService;
 import com.example.web_spring.Delivery.Delivery;
+import com.example.web_spring.Delivery.DeliveryState;
 import com.example.web_spring.Member.Member;
 import com.example.web_spring.Member.MemberRepository;
 import com.example.web_spring.OrderItem.OrderItem;
@@ -114,5 +115,28 @@ public class OrderService {
 
         order.setStatus(OrderStatus.CANCELED);
     }
+
+    @Transactional
+    public void refundOrder(Long orderId, String username) {
+
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다."));
+
+        if (!order.getMember().getUsername().equals(username)) {
+            throw new IllegalStateException("본인의 주문만 반품할 수 있습니다.");
+        }
+
+        // 배송완료 상태에서만 반품 가능
+        if (order.getStatus() != OrderStatus.DELIVERED) {
+            throw new IllegalStateException("배송완료 상태에서만 반품 요청이 가능합니다.");
+        }
+
+        // 배송 상태 변경
+        order.getDelivery().setState(DeliveryState.RETURN_REQUESTED);
+
+        // 주문 상태 변경
+        order.setStatus(OrderStatus.REFUNDED);
+    }
+
 
 }

--- a/src/main/java/com/example/web_spring/Order/OrderService.java
+++ b/src/main/java/com/example/web_spring/Order/OrderService.java
@@ -1,10 +1,16 @@
 package com.example.web_spring.Order;
 
+import com.example.web_spring.Cart.Cart;
+import com.example.web_spring.Cart.CartService;
 import com.example.web_spring.Member.Member;
 import com.example.web_spring.Member.MemberRepository;
+import com.example.web_spring.OrderItem.OrderItem;
+import com.example.web_spring.Payment.PaymentMethod;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -12,6 +18,8 @@ public class OrderService {
 
     private final TemporaryOrderRepository temporaryOrderRepository;
     private final MemberRepository memberRepository;
+    private final CartService cartService;
+    private final OrderRepository orderRepository;
 
     @Transactional
     public void saveTemporaryOrder(OrderFormDto form, String username) {
@@ -23,4 +31,60 @@ public class OrderService {
 
         temporaryOrderRepository.save(temp);
     }
+
+    @Transactional(readOnly = true)
+    public TemporaryOrder getTemporaryOrder(String username) {
+
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+        return temporaryOrderRepository.findTopByMemberOrderByIdDesc(member)
+                .orElseThrow(() -> new IllegalStateException("임시 주문 정보가 없습니다."));
+    }
+    @Transactional
+    public Long completeOrder(String username, PaymentMethod method) {
+
+        // 1) 회원 조회
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+        // 2) 임시 주문 조회 (배송지 정보)
+        TemporaryOrder temp = temporaryOrderRepository.findTopByMemberOrderByIdDesc(member)
+                .orElseThrow(() -> new IllegalStateException("임시 주문 정보가 없습니다."));
+
+        // 3) 장바구니 목록 조회
+        List<Cart> cartItems = cartService.getCartItems(username);
+
+        // 4) 총 금액 계산
+        int totalPrice = cartItems.stream()
+                .mapToInt(item -> item.getPrice() * item.getQuantity())
+                .sum();
+
+        // 5) 본 주문(Order) 생성
+        Order order = Order.create(member, temp, totalPrice, method);
+
+        // 6) 각 장바구니 상품을 OrderItem으로 변환
+        for (Cart cart : cartItems) {
+
+            OrderItem item = OrderItem.create(
+                    cart.getProduct(),
+                    cart.getQuantity(),
+                    cart.getPrice()
+            );
+
+            order.addOrderItem(item); // order와 item의 양방향 설정
+        }
+
+        // 7) DB 저장
+        orderRepository.save(order);
+
+        // 8) 장바구니 비우기
+        cartService.clearCart(username);
+
+        // 9) 임시 주문 삭제
+        temporaryOrderRepository.delete(temp);
+
+        return order.getId();
+    }
+
 }

--- a/src/main/java/com/example/web_spring/Order/OrderService.java
+++ b/src/main/java/com/example/web_spring/Order/OrderService.java
@@ -1,0 +1,26 @@
+package com.example.web_spring.Order;
+
+import com.example.web_spring.Member.Member;
+import com.example.web_spring.Member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final TemporaryOrderRepository temporaryOrderRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void saveTemporaryOrder(OrderFormDto form, String username) {
+
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("회원 정보 없음"));
+
+        TemporaryOrder temp = TemporaryOrder.create(member, form);
+
+        temporaryOrderRepository.save(temp);
+    }
+}

--- a/src/main/java/com/example/web_spring/Order/OrderStatus.java
+++ b/src/main/java/com/example/web_spring/Order/OrderStatus.java
@@ -1,11 +1,35 @@
 package com.example.web_spring.Order;
 
 public enum OrderStatus {
-    PAYMENT_PENDING, // 결제전
-    PAYMENT_COMPLETED, // 결제완료
-    PREPARING_SHIPMENT, // 상품준비
-    SHIPPING, // 배송증
-    DELIVERED, // 배송완료
-    CANCELED, // 주문취소
-    REFUNDED // 환불
+    PAYMENT_PENDING,       // 결제 대기
+    PAYMENT_COMPLETED,     // 결제 완료
+    PREPARING_SHIPMENT,    // 상품 준비 중
+    SHIPPING,              // 배송 중
+    DELIVERED,             // 배송 완료
+    CANCELED,              // 주문 취소
+    REFUNDED;              // 환불 완료
+
+    public String getKorean() {
+        return switch (this) {
+            case PAYMENT_PENDING -> "결제 대기";
+            case PAYMENT_COMPLETED -> "결제 완료";
+            case PREPARING_SHIPMENT -> "상품 준비 중";
+            case SHIPPING -> "배송 중";
+            case DELIVERED -> "배송 완료";
+            case CANCELED -> "주문 취소";
+            case REFUNDED -> "환불 완료";
+        };
+    }
+
+    public String getBadgeClass() {
+        return switch (this) {
+            case PAYMENT_PENDING -> "secondary";
+            case PAYMENT_COMPLETED -> "success";
+            case PREPARING_SHIPMENT -> "info";
+            case SHIPPING -> "primary";
+            case DELIVERED -> "dark";
+            case CANCELED -> "danger";
+            case REFUNDED -> "warning";
+        };
+    }
 }

--- a/src/main/java/com/example/web_spring/Order/OrderStatus.java
+++ b/src/main/java/com/example/web_spring/Order/OrderStatus.java
@@ -27,7 +27,7 @@ public enum OrderStatus {
             case PAYMENT_COMPLETED -> "success";
             case PREPARING_SHIPMENT -> "info";
             case SHIPPING -> "primary";
-            case DELIVERED -> "dark";
+            case DELIVERED -> "light";
             case CANCELED -> "danger";
             case REFUNDED -> "warning";
         };

--- a/src/main/java/com/example/web_spring/Order/OrderStatus.java
+++ b/src/main/java/com/example/web_spring/Order/OrderStatus.java
@@ -1,6 +1,6 @@
 package com.example.web_spring.Order;
 
-enum OrderStatus {
+public enum OrderStatus {
     PAYMENT_PENDING, // 결제전
     PAYMENT_COMPLETED, // 결제완료
     PREPARING_SHIPMENT, // 상품준비

--- a/src/main/java/com/example/web_spring/Order/TemporaryOrder.java
+++ b/src/main/java/com/example/web_spring/Order/TemporaryOrder.java
@@ -1,0 +1,32 @@
+package com.example.web_spring.Order;
+
+import com.example.web_spring.Member.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class TemporaryOrder {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    private String receiver;
+    private String phoneNumber;
+    private String address;
+
+    public static TemporaryOrder create(Member member, OrderFormDto dto) {
+        TemporaryOrder order = new TemporaryOrder();
+        order.member = member;
+        order.receiver = dto.getReceiver();
+        order.phoneNumber = dto.getPhoneNumber();
+        order.address = dto.getAddress();
+        return order;
+    }
+}

--- a/src/main/java/com/example/web_spring/Order/TemporaryOrderRepository.java
+++ b/src/main/java/com/example/web_spring/Order/TemporaryOrderRepository.java
@@ -1,0 +1,6 @@
+package com.example.web_spring.Order;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TemporaryOrderRepository extends JpaRepository<TemporaryOrder, Long> {
+}

--- a/src/main/java/com/example/web_spring/Order/TemporaryOrderRepository.java
+++ b/src/main/java/com/example/web_spring/Order/TemporaryOrderRepository.java
@@ -1,6 +1,10 @@
 package com.example.web_spring.Order;
 
+import com.example.web_spring.Member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TemporaryOrderRepository extends JpaRepository<TemporaryOrder, Long> {
+    Optional<TemporaryOrder> findTopByMemberOrderByIdDesc(Member member);
 }

--- a/src/main/java/com/example/web_spring/Order/TemporaryOrderRepository.java
+++ b/src/main/java/com/example/web_spring/Order/TemporaryOrderRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface TemporaryOrderRepository extends JpaRepository<TemporaryOrder, Long> {
     Optional<TemporaryOrder> findTopByMemberOrderByIdDesc(Member member);
+    Optional<TemporaryOrder> findByMember(Member member);
 }

--- a/src/main/java/com/example/web_spring/OrderItem/OrderItem.java
+++ b/src/main/java/com/example/web_spring/OrderItem/OrderItem.java
@@ -4,11 +4,13 @@ import com.example.web_spring.Order.Order;
 import com.example.web_spring.Product.Product;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 
 @Entity
 @Getter @Setter
+@NoArgsConstructor
 public class OrderItem {
 
     @Id
@@ -33,6 +35,12 @@ public class OrderItem {
         item.quantity = quantity;
         item.price = price;
         return item;
+    }
+    public OrderItem(Order order, Product product, int quantity, int price) {
+        this.order = order;
+        this.product = product;
+        this.quantity = quantity;
+        this.price = price;
     }
 
     public void setOrder(Order order) {

--- a/src/main/java/com/example/web_spring/OrderItem/OrderItem.java
+++ b/src/main/java/com/example/web_spring/OrderItem/OrderItem.java
@@ -26,4 +26,16 @@ public class OrderItem {
 
     private int quantity;
     private int price;
+
+    public static OrderItem create(Product product, int quantity, int price) {
+        OrderItem item = new OrderItem();
+        item.product = product;
+        item.quantity = quantity;
+        item.price = price;
+        return item;
+    }
+
+    public void setOrder(Order order) {
+        this.order = order;
+    }
 }

--- a/src/main/java/com/example/web_spring/Payment/PaymentController.java
+++ b/src/main/java/com/example/web_spring/Payment/PaymentController.java
@@ -1,0 +1,44 @@
+package com.example.web_spring.Payment;
+
+import com.example.web_spring.Cart.CartService;
+import com.example.web_spring.Order.OrderService;
+import com.example.web_spring.Order.TemporaryOrder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+
+@Controller
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final CartService cartService;
+    private final OrderService orderService;
+
+    @GetMapping("/payment")
+    public String paymentPage(Model model, Principal principal) {
+
+        String username = principal.getName();
+
+        model.addAttribute("orderTotal", cartService.getTotalPrice(username));
+        model.addAttribute("orderCount", cartService.getTotalQuantity(username));
+
+        TemporaryOrder tempOrder = orderService.getTemporaryOrder(username);
+        model.addAttribute("tempOrder", tempOrder);
+
+        return "payment/payment";
+    }
+
+    @PostMapping("/payment")
+    public String pay(@RequestParam String paymentMethod,
+                      Principal principal) {
+
+        String username = principal.getName();
+
+        Long orderId = orderService.completeOrder(username, PaymentMethod.valueOf(paymentMethod));
+
+        return "redirect:/order/complete/" + orderId;
+    }
+}

--- a/src/main/java/com/example/web_spring/Payment/PaymentMethod.java
+++ b/src/main/java/com/example/web_spring/Payment/PaymentMethod.java
@@ -1,0 +1,7 @@
+package com.example.web_spring.Payment;
+
+public enum PaymentMethod {
+    CARD,       // 신용/체크카드
+    BANK,       // 계좌이체
+    KAKAO       // 카카오페이
+}

--- a/src/main/java/com/example/web_spring/Product/ProductRepository.java
+++ b/src/main/java/com/example/web_spring/Product/ProductRepository.java
@@ -12,4 +12,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("SELECT p FROM Product p WHERE p.category.name = :name")
     List<Product> findByCategoryName(@Param("name") String name);
 
+    Optional<Product> findByName(String name);
+
 }

--- a/src/main/java/com/example/web_spring/global/DataInitializer.java
+++ b/src/main/java/com/example/web_spring/global/DataInitializer.java
@@ -157,7 +157,7 @@ public class DataInitializer implements CommandLineRunner {
                     "서울시 강남구 테헤란로 101",
                     1200000,
                     PaymentMethod.CARD,
-                    OrderStatus.DELIVERED
+                    OrderStatus.PAYMENT_COMPLETED
             );
 
             OrderItem item1 = new OrderItem(order1, phoneProduct, 1, phoneProduct.getPrice());
@@ -178,7 +178,7 @@ public class DataInitializer implements CommandLineRunner {
                     "서울시 강남구 테헤란로 101",
                     3200000,
                     PaymentMethod.CARD,
-                    OrderStatus.CANCELED
+                    OrderStatus.DELIVERED
             );
 
             OrderItem item2 = new OrderItem(order2, macProduct, 1, macProduct.getPrice());

--- a/src/main/java/com/example/web_spring/global/DataInitializer.java
+++ b/src/main/java/com/example/web_spring/global/DataInitializer.java
@@ -7,10 +7,21 @@ import com.example.web_spring.Category.Category;
 import com.example.web_spring.Category.CategoryRepository;
 import com.example.web_spring.Product.Product;
 import com.example.web_spring.Product.ProductRepository;
+import com.example.web_spring.Order.Order;
+import com.example.web_spring.Order.OrderRepository;
+import com.example.web_spring.Order.OrderStatus;
+import com.example.web_spring.OrderItem.OrderItem;
+import com.example.web_spring.OrderItem.OrderItemRepository;
+import com.example.web_spring.Delivery.Delivery;
+import com.example.web_spring.Delivery.DeliveryRepository;
+import com.example.web_spring.Delivery.DeliveryState;
+import com.example.web_spring.Payment.PaymentMethod;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -19,6 +30,11 @@ public class DataInitializer implements CommandLineRunner {
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
     private final ProductRepository productRepository;
+
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final DeliveryRepository deliveryRepository;
+
     private final PasswordEncoder passwordEncoder;
 
     @Override
@@ -35,9 +51,7 @@ public class DataInitializer implements CommandLineRunner {
                     .phone("010-0000-0000")
                     .role(Role.ROLE_ADMIN)
                     .build();
-
             memberRepository.save(admin);
-            System.out.println("✅ 관리자 계정 생성 완료 (admin / 1234)");
         }
 
         if (memberRepository.findByUsername("user").isEmpty()) {
@@ -48,19 +62,18 @@ public class DataInitializer implements CommandLineRunner {
                     .phone("010-1111-1111")
                     .role(Role.ROLE_USER)
                     .build();
-
             memberRepository.save(user);
-            System.out.println("✅ 사용자 계정 생성 완료 (user / 1234)");
         }
+
 
         // -----------------------
         // 2. 카테고리 생성
         // -----------------------
         if (categoryRepository.count() == 0) {
-            Category laptop = categoryRepository.save(new Category("노트북"));
-            Category phone = categoryRepository.save(new Category("스마트폰"));
-            Category monitor = categoryRepository.save(new Category("모니터"));
-            Category accessory = categoryRepository.save(new Category("악세서리"));
+            categoryRepository.save(new Category("노트북"));
+            categoryRepository.save(new Category("스마트폰"));
+            categoryRepository.save(new Category("모니터"));
+            categoryRepository.save(new Category("악세서리"));
 
             System.out.println("✅ 기본 카테고리 생성 완료");
         }
@@ -119,17 +132,64 @@ public class DataInitializer implements CommandLineRunner {
                     .description("노이즈 캔슬링 무선 이어폰")
                     .imageUrl("/images/airpods.jpg")
                     .stock(30)
-                    .category(accessory)   // 악세서리 카테고리
+                    .category(accessory)
                     .build();
 
+            productRepository.saveAll(List.of(p1, p2, p3, p4, p5));
+        }
 
-            productRepository.save(p1);
-            productRepository.save(p2);
-            productRepository.save(p3);
-            productRepository.save(p4);
-            productRepository.save(p5);
 
-            System.out.println("✅ 상품 더미 데이터 생성 완료");
+        // -----------------------
+        // 4. 주문 더미 데이터 생성
+        // -----------------------
+        Member user = memberRepository.findByUsername("user").orElse(null);
+
+        if (user != null && orderRepository.count() == 0) {
+
+            Product phoneProduct = productRepository.findByName("아이폰 15").orElse(null);
+            Product macProduct = productRepository.findByName("맥북 프로").orElse(null);
+
+            // ===== 1) 배송완료 주문 생성 =====
+            Order order1 = new Order(
+                    user,
+                    "홍길동",
+                    "010-2222-2222",
+                    "서울시 강남구 테헤란로 101",
+                    1200000,
+                    PaymentMethod.CARD,
+                    OrderStatus.DELIVERED
+            );
+
+            OrderItem item1 = new OrderItem(order1, phoneProduct, 1, phoneProduct.getPrice());
+            order1.addOrderItem(item1);
+
+            Delivery d1 = new Delivery(order1, "111-222-333", "서울시 강남구 테헤란로 101", DeliveryState.DELIVERED);
+            order1.setDelivery(d1);
+
+            orderRepository.save(order1);
+
+
+
+            // ===== 2) 주문취소 주문 생성 =====
+            Order order2 = new Order(
+                    user,
+                    "홍길동",
+                    "010-2222-2222",
+                    "서울시 강남구 테헤란로 101",
+                    3200000,
+                    PaymentMethod.CARD,
+                    OrderStatus.CANCELED
+            );
+
+            OrderItem item2 = new OrderItem(order2, macProduct, 1, macProduct.getPrice());
+            order2.addOrderItem(item2);
+
+            Delivery d2 = new Delivery(order2, "준비중", "서울시 강남구 테헤란로 101", DeliveryState.READY);
+            order2.setDelivery(d2);
+
+            orderRepository.save(order2);
+
+            System.out.println("✅ 더미 주문 데이터 2건 생성 완료 (배송완료 + 주문취소)");
         }
     }
 }

--- a/src/main/resources/templates/cart/cart.html
+++ b/src/main/resources/templates/cart/cart.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>장바구니 - 전자기기몰</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+
+    <style>
+        .cart-img {
+            width: 100px;
+            height: 100px;
+            object-fit: cover;
+            border-radius: 6px;
+        }
+    </style>
+</head>
+
+<body>
+
+<!-- ⭐ 공통 헤더 적용 -->
+<div th:replace="fragments/header :: top-utility-bar"></div>
+<div th:replace="fragments/header :: navbar"></div>
+
+<div class="container mt-5">
+    <h2 class="mb-4">장바구니</h2>
+
+    <!-- 장바구니 비어있을 때 -->
+    <div th:if="${#lists.isEmpty(cartItems)}" class="text-center py-5">
+        <h4 class="text-muted">장바구니가 비어 있습니다.</h4>
+        <a href="/products" class="btn btn-primary mt-3">상품 보러가기</a>
+    </div>
+
+    <!-- 장바구니 목록 -->
+    <div th:if="${!#lists.isEmpty(cartItems)}">
+
+        <table class="table align-middle">
+            <thead class="table-light">
+            <tr>
+                <th>상품</th>
+                <th>상품명</th>
+                <th>가격</th>
+                <th>수량</th>
+                <th>총합</th>
+                <th></th>
+            </tr>
+            </thead>
+
+            <tbody>
+            <tr th:each="item : ${cartItems}">
+
+                <!-- 상품 이미지 -->
+                <td>
+                    <img th:src="@{${item.product.imageUrl}}" class="cart-img" alt="상품 이미지">
+                </td>
+
+                <!-- 상품명 -->
+                <td th:text="${item.product.name}"></td>
+
+                <!-- 가격 -->
+                <td th:text="${#numbers.formatInteger(item.product.price, 3, 'COMMA')} + '원'"></td>
+
+                <!-- 수량 조절 -->
+                <td>
+                    <div class="d-flex align-items-center gap-2">
+
+                        <!-- 수량 -1 -->
+                        <form th:action="@{/cart/minus/{id}(id=${item.product.id})}" method="post">
+                            <button class="btn btn-outline-secondary btn-sm">-</button>
+                        </form>
+
+                        <span th:text="${item.quantity}" class="px-2 fw-bold"></span>
+
+                        <!-- 수량 +1 -->
+                        <form th:action="@{/cart/plus/{id}(id=${item.product.id})}" method="post">
+                            <button class="btn btn-outline-secondary btn-sm">+</button>
+                        </form>
+                    </div>
+                </td>
+
+                <!-- 총합 -->
+                <td class="fw-bold text-primary"
+                    th:text="${#numbers.formatInteger(item.product.price * item.quantity, 3, 'COMMA')} + '원'">
+                </td>
+
+                <!-- 삭제 버튼 -->
+                <td>
+                    <form th:action="@{/cart/delete/{id}(id=${item.product.id})}" method="post">
+                        <button class="btn btn-outline-danger btn-sm">삭제</button>
+                    </form>
+                </td>
+
+            </tr>
+            </tbody>
+        </table>
+
+        <!-- 총합 + 주문 버튼 -->
+        <div class="d-flex justify-content-end align-items-center mt-4">
+
+            <h4 class="me-4">
+                총 주문 금액:
+                <span class="text-danger fw-bold"
+                      th:text="${#numbers.formatInteger(totalPrice, 3, 'COMMA')} + '원'"></span>
+            </h4>
+
+            <a href="/order" class="btn btn-success btn-lg">
+                주문하기
+            </a>
+        </div>
+
+    </div>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/main/mypage.html
+++ b/src/main/resources/templates/main/mypage.html
@@ -7,6 +7,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </head>
 <body>
+
 <!-- 헤더 -->
 <div th:replace="fragments/header :: top-utility-bar"></div>
 <div th:replace="fragments/header :: navbar"></div>
@@ -21,7 +22,13 @@
             <p><strong>이름:</strong> <span th:text="${username}">홍길동</span></p>
             <p><strong>이메일:</strong> <span th:text="${email}">example@domain.com</span></p>
             <p><strong>전화번호:</strong> <span th:text="${phone}">010-0000-0000</span></p>
-            <a href="/mypage/edit" class="btn btn-primary">정보 수정</a>
+
+            <a href="/mypage/edit" class="btn btn-primary me-2">정보 수정</a>
+
+            <!-- 🔥 주문내역 바로가기 버튼 추가 -->
+            <a href="/mypage/orders" class="btn btn-outline-dark">
+                주문내역 보기
+            </a>
         </div>
     </div>
 
@@ -30,22 +37,27 @@
         <div class="card-header">문의내역</div>
         <div class="card-body">
             <div class="list-group">
+
+                <!-- 실제 문의 데이터 -->
                 <div class="list-group-item" th:each="inquiry : ${inquiries}">
                     <strong th:text="${inquiry.title}">문의 제목</strong>
                     <p th:text="${inquiry.content}">문의 내용</p>
                     <small class="text-muted" th:text="${inquiry.date}">2025-11-25</small>
                 </div>
-                <!-- 더미 예시 -->
+
+                <!-- 더미 문의 -->
                 <div class="list-group-item">
                     <strong>배송 문의</strong>
                     <p>주문한 상품이 언제 도착하나요?</p>
                     <small class="text-muted">2025-11-20</small>
                 </div>
+
                 <div class="list-group-item">
                     <strong>반품 문의</strong>
                     <p>상품 교환은 어떻게 하나요?</p>
                     <small class="text-muted">2025-11-22</small>
                 </div>
+
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/mypage/order_list.html
+++ b/src/main/resources/templates/mypage/order_list.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>주문 내역</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+
+<body class="container mt-5">
+
+<h2 class="mb-4">📦 주문 내역</h2>
+
+<table class="table table-hover text-center align-middle">
+    <thead class="table-dark">
+    <tr>
+        <th>주문번호</th>
+        <th>주문일자</th>
+        <th>상품수</th>
+        <th>결제금액</th>
+        <th>결제상태</th>
+        <th>배송상태</th>
+        <th>관리</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    <tr th:each="order : ${orders}">
+        <!-- 주문 번호 -->
+        <td th:text="${order.id}"></td>
+
+        <!-- 주문 날짜 -->
+        <td th:text="${#temporals.format(order.orderDate, 'yyyy-MM-dd HH:mm')}"></td>
+
+        <!-- 주문 상품 수 -->
+        <td th:text="${order.orderItems.size()} + '개'"></td>
+
+        <!-- 총 결제 금액 -->
+        <td th:text="${#numbers.formatInteger(order.totalPrice, 3, 'COMMA')} + '원'"></td>
+
+        <!-- 주문 상태 뱃지 -->
+        <td>
+    <span class="badge px-3 py-2 text-dark"
+          th:class="'badge bg-' + ${order.status.badgeClass} + ' text-dark'"
+          th:text="${order.status.korean}">
+    </span>
+        </td>
+
+        <!-- 배송 상태 뱃지 -->
+        <td>
+    <span class="badge px-3 py-2 text-dark"
+          th:class="'badge bg-' + ${order.delivery.state.badgeClass} + ' text-dark'"
+          th:text="${order.delivery.state.korean}">
+    </span>
+        </td>
+
+
+
+        <!-- 관리 버튼 -->
+        <td>
+
+            <!-- 상세보기 -->
+            <a class="btn btn-sm btn-primary me-2"
+               th:href="@{/order/detail/{id}(id=${order.id})}">
+                상세보기
+            </a>
+
+            <!-- 주문 취소 버튼: 배송 전 상태에서만 -->
+            <form th:if="${order.status == T(com.example.web_spring.Order.OrderStatus).PAYMENT_COMPLETED}"
+                  th:action="@{/order/cancel/{id}(id=${order.id})}"
+                  method="post" class="d-inline">
+                <button class="btn btn-sm btn-danger">주문 취소</button>
+            </form>
+
+            <!-- 반품 버튼: 배송완료 상태에서만 -->
+            <form th:if="${order.status == T(com.example.web_spring.Order.OrderStatus).DELIVERED}"
+                  th:action="@{/order/refund/{id}(id=${order.id})}"
+                  method="post" class="d-inline">
+                <button class="btn btn-sm btn-warning text-white">반품</button>
+            </form>
+
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+</body>
+</html>

--- a/src/main/resources/templates/order/order_complete.html
+++ b/src/main/resources/templates/order/order_complete.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>주문 완료</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+
+<body class="bg-light">
+
+<div class="container mt-5" style="max-width: 700px;">
+
+    <h2 class="mb-4 text-center">주문이 완료되었습니다 🎉</h2>
+
+    <div class="card mb-4">
+        <div class="card-header fw-bold">
+            주문 정보
+        </div>
+        <div class="card-body">
+            <p>주문번호: <strong th:text="${order.id}"></strong></p>
+            <p>주문일자: <strong th:text="${order.orderDate}"></strong></p>
+            <p>총 금액: <strong th:text="${order.totalPrice} + '원'"></strong></p>
+            <p>결제수단: <strong th:text="${order.paymentMethod}"></strong></p>
+        </div>
+    </div>
+
+    <div class="d-flex justify-content-between mt-4">
+        <a href="/mypage/orders" class="btn btn-primary">주문 내역 보기</a>
+        <a href="/" class="btn btn-secondary">메인으로</a>
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/order/order_form.html
+++ b/src/main/resources/templates/order/order_form.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>주문 / 배송지 입력</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+
+<body class="bg-light">
+
+<div class="container mt-5" style="max-width: 700px;">
+    <h2 class="mb-4">주문 / 배송지 정보 입력</h2>
+
+    <!-- 주문 요약 영역 -->
+    <div class="card mb-4">
+        <div class="card-header fw-bold">
+            주문 상품 정보
+        </div>
+        <div class="card-body">
+            <p class="mb-1">총 상품 금액:
+                <strong th:text="${orderTotal}"></strong> 원
+            </p>
+            <p class="mb-0">총 수량:
+                <strong th:text="${orderCount}"></strong> 개
+            </p>
+        </div>
+    </div>
+
+    <!-- 배송지 입력 폼 -->
+    <form th:action="@{/order}" method="post">
+
+        <div class="mb-3">
+            <label for="receiver" class="form-label">수령인</label>
+            <input type="text" class="form-control" id="receiver" name="receiver" required>
+        </div>
+
+        <div class="mb-3">
+            <label for="phoneNumber" class="form-label">휴대폰 번호</label>
+            <input type="text" class="form-control" id="phoneNumber" name="phoneNumber"
+                   placeholder="010-0000-0000" required>
+        </div>
+
+        <div class="mb-3">
+            <label for="address" class="form-label">주소</label>
+            <input type="text" class="form-control" id="address" name="address"
+                   placeholder="배송 받을 주소를 입력하세요" required>
+        </div>
+
+        <div class="d-flex justify-content-between mt-4">
+            <a href="/cart" class="btn btn-secondary">장바구니로 돌아가기</a>
+            <button type="submit" class="btn btn-primary">다음 단계 (결제)</button>
+        </div>
+
+    </form>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/payment/payment.html
+++ b/src/main/resources/templates/payment/payment.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>결제하기</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+
+<body class="bg-light">
+
+<div class="container mt-5" style="max-width: 800px;">
+
+  <h2 class="mb-4">결제하기</h2>
+
+  <!-- 주문 요약 -->
+  <div class="card mb-4">
+    <div class="card-header fw-bold">주문 요약</div>
+    <div class="card-body">
+      <p>총 상품 금액: <strong th:text="${orderTotal}"></strong> 원</p>
+      <p>총 수량: <strong th:text="${orderCount}"></strong> 개</p>
+    </div>
+  </div>
+
+  <!-- 배송지 정보 -->
+  <div class="card mb-4">
+    <div class="card-header fw-bold">배송지 정보</div>
+    <div class="card-body">
+      <p>수령인: <strong th:text="${tempOrder.receiver}"></strong></p>
+      <p>연락처: <strong th:text="${tempOrder.phoneNumber}"></strong></p>
+      <p>주소: <strong th:text="${tempOrder.address}"></strong></p>
+    </div>
+  </div>
+
+  <!-- 결제 수단 -->
+  <form th:action="@{/payment}" method="post">
+
+    <div class="card mb-4">
+      <div class="card-header fw-bold">결제 수단 선택</div>
+      <div class="card-body">
+
+        <div class="form-check mb-2">
+          <input class="form-check-input" type="radio" name="paymentMethod" value="CARD" checked>
+          <label class="form-check-label">신용/체크카드</label>
+        </div>
+
+        <div class="form-check mb-2">
+          <input class="form-check-input" type="radio" name="paymentMethod" value="BANK">
+          <label class="form-check-label">계좌이체</label>
+        </div>
+
+        <div class="form-check">
+          <input class="form-check-input" type="radio" name="paymentMethod" value="KAKAO">
+          <label class="form-check-label">카카오페이</label>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- 버튼 -->
+    <div class="d-flex justify-content-between">
+      <a href="/order" class="btn btn-secondary">이전 단계</a>
+      <button type="submit" class="btn btn-primary">결제하기</button>
+    </div>
+
+  </form>
+
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/products/detail.html
+++ b/src/main/resources/templates/products/detail.html
@@ -50,8 +50,8 @@
     <!-- 버튼 그룹 -->
     <div class="mt-4 d-flex gap-3 flex-wrap">
 
-      <a href="#" class="btn btn-success btn-lg">
-        주문하기
+      <a th:href="@{/order}" class="btn btn-success btn-lg">
+        🧾 주문하기
       </a>
 
       <!-- 장바구니 담기 버튼 -->

--- a/src/main/resources/templates/products/detail.html
+++ b/src/main/resources/templates/products/detail.html
@@ -54,9 +54,12 @@
         주문하기
       </a>
 
-      <a href="#" class="btn btn-warning btn-lg text-white">
-        장바구니 담기
-      </a>
+      <!-- 장바구니 담기 버튼 -->
+      <form th:action="@{/cart/add/{id}(id=${product.id})}" method="post" style="display:inline;">
+        <button type="submit" class="btn btn-warning btn-lg text-white">
+          🛒 장바구니 담기
+        </button>
+      </form>
 
       <form th:action="@{/products/wish(id=${product.id})}" method="post">
         <button type="submit" class="btn btn-outline-danger btn-lg">


### PR DESCRIPTION
## 📌 Issue: 장바구니 ~ 결제 ~ 주문내역 및 주문/배송 상태 기능 구현

### 🎯 목적
사용자가 장바구니에서 주문을 진행하여 결제(안내 메시지) 후,
주문내역 및 주문/배송 상태(주문취소, 반품)를 확인할 수 있는 기본 구매 흐름을 구현한다.

---

### 🛠 해야 할 작업

#### 🛒 1. 장바구니 페이지
- [x] Controller: `GET /cart` 장바구니 화면 조회
- [x] Service: 장바구니 항목 조회 로직
- [x] View: 장바구니 템플릿 (`cart.html`)
- [x] 장바구니에서 "주문하기" 클릭 시 → `/order` 로 이동

#### 📦 2. 주문/배송지 정보 입력
- [x] Controller: `GET /order` 주문/배송지 정보 입력폼
- [x] Controller: `POST /order` 주문/배송지 정보 제출
- [x] Service: 주문/배송지 정보 검증 및 임시 주문 정보 생성
- [x] View: 주문/배송지 입력 템플릿 (`order_form.html`)
- [x] 주문정보 입력 완료 시 → `/payment` 로 이동

#### 💳 3. 결제 페이지 (안내 메시지 출력)
> 실제 결제 연동은 하지 않고, 안내 메시지만 출력

- [x] Controller: `GET /payment` 결제 안내 페이지
- [ ] View: 결제 안내 템플릿 (`payment.html`)
  - 예: “현재는 결제 연동 전 단계입니다. ‘결제 완료’ 버튼을 누르면 주문이 생성됩니다.”
- [ ] "결제 완료" 버튼 클릭 시 → `POST /payment/complete`
- [ ] Controller: `POST /payment/complete`
  - [ ] Service: 실제 주문 엔티티 생성 + 주문상태(예: `ORDERED`) 저장
  - [ ] 처리 완료 후 → `/orders` (주문내역 목록) 리다이렉트

#### 📃 4. 주문내역 목록 / 상세 보기
- [x] Controller: `GET /orders` 주문내역 목록
- [x] Service: 로그인한 회원의 주문 리스트 조회
- [x] View: 주문내역 목록 템플릿 (`orders.html`)
- [ ] Controller: `GET /orders/{orderId}` 주문 상세/상태 페이지
- [ ] View: 주문 상세 템플릿 (`order_detail.html`)

#### 🚚 5. 주문/배송 상태 + 주문취소/반품
- [x] 주문 상태 필드 설계 (예: `ORDERED`, `SHIPPED`, `DELIVERED`, `CANCELLED`, `RETURNED` 등)
- [x] Controller: `POST /orders/{orderId}/cancel`
  - [x] Service: 주문취소 처리(상태 `CANCELLED` 변경, 비즈니스 룰 검증)
- [x] Controller: `POST /orders/{orderId}/return`
  - [x] Service: 반품 처리(상태 `RETURNED` 변경, 비즈니스 룰 검증)
- [x] 주문 상세 페이지에서 현재 상태에 따라 “주문취소”, “반품” 버튼 노출

---

## closed issue
#4 